### PR TITLE
Fixes for r5-130

### DIFF
--- a/offsets/src/analysis/concommands.rs
+++ b/offsets/src/analysis/concommands.rs
@@ -66,7 +66,7 @@ pub fn concommands(bin: PeFile<'_>) -> Vec<ConCommand<'_>> {
 	let mut concommands = Vec::new();
 	let mut save = [0; 4];
 	// Find the ConCommand vtable
-	if !bin.scanner().finds_code(pat!("8D?${'} 33FF ?891D???? ?8D"), &mut save) {
+	if !bin.scanner().matches_code(pat!("488D05${} 488905${*{'}} 4885D2")).next(&mut save) {
 		crate::print_error(&"ERR: unable to find ConCommand vftable");
 		return concommands;
 	}

--- a/offsets/src/analysis/convars.rs
+++ b/offsets/src/analysis/convars.rs
@@ -87,7 +87,7 @@ pub struct ConVar<'a> {
 pub fn convars(bin: PeFile<'_>) -> Vec<ConVar<'_>> {
 	// Find the main ConVar vtable
 	let mut save = [0; 4];
-	if !bin.scanner().finds_code(pat!("488BC8 488BD3 E8$ 4053 4883EC60 488BD9 C6411000 33C9 488D05$'"), &mut save) {
+	if !bin.scanner().matches_code(pat!("4C8D35${'} 881D")).next(&mut save) {
 		crate::print_error(&"ERR: unable to find ConVar vftable");
 		return Vec::new();
 	}

--- a/offsets/src/analysis/misc.rs
+++ b/offsets/src/analysis/misc.rs
@@ -76,7 +76,7 @@ fn local_player(f: &mut super::Output, bin: PeFile<'_>) {
 
 fn global_vars(f: &mut super::Output, bin: PeFile<'_>) {
 	// Right above "Client.dll Init_PostVideo() in library "
-	// lea r8, qword_XXX
+	// lea rdx, qword_XXX
 	let mut save = [0; 4];
 	if bin.scanner().finds_code(pat!("488B01 488D15${'} [10-20] $\"Client.dll Init_PostVideo\""), &mut save) {
 		let global_vars = save[1];

--- a/offsets/src/analysis/misc.rs
+++ b/offsets/src/analysis/misc.rs
@@ -78,7 +78,7 @@ fn global_vars(f: &mut super::Output, bin: PeFile<'_>) {
 	// Right above "Client.dll Init_PostVideo() in library "
 	// lea r8, qword_XXX
 	let mut save = [0; 4];
-	if bin.scanner().finds_code(pat!("488B01 4C8D05${'} [10-20] $\"Client.dll Init_PostVideo\""), &mut save) {
+	if bin.scanner().finds_code(pat!("488B01 488D15${'} [10-20] $\"Client.dll Init_PostVideo\""), &mut save) {
 		let global_vars = save[1];
 		let _ = writeln!(f.ini, "GlobalVars={:#x}", global_vars);
 	}


### PR DESCRIPTION
This PR fixes:

 * ConCommand vftable finding with a non-unique pattern (has a chance of a false positive, but rn that place is in the middle of the binary among 9001 valid results)
 * ConVar vftable finding with a non-unique pattern (has like ~3 hits)
 * GlobalVars (function prototype was changed)

There only a few hours until update goes live /shrug
Was tested on the upcoming version used for leaks. Dump wasn't complete though, so many of my fields are 0 and I have 0 means of actually running it. If it's still broken, more people are welcome to fix it.