### PR TITLE
Add CWeaponX!m_singlefire pattern to misc.rs

### DIFF
--- a/offsets/src/analysis/misc.rs
+++ b/offsets/src/analysis/misc.rs
@@ -17,6 +17,7 @@ pub fn print(f: &mut super::Output, bin: PeFile<'_>) {
 	view_render(f, bin);
 	client_state(f, bin);
 	projectile_speed(f, bin);
+	weapon_singlefire(f, bin);
 	unknown_magic(f, bin);
 	local_camera(f, bin);
 	studio_hdr(f, bin);
@@ -186,6 +187,19 @@ fn projectile_speed(f: &mut super::Output, bin: PeFile<'_>) {
 	}
 	else {
 		crate::print_error("unable to find projectile_speed");
+	}
+}
+
+fn weapon_singlefire(f: &mut super::Output, bin: PeFile<'_>) {
+	// Credits: https://www.unknowncheats.me/forum/3403807-post9036.html
+	// Find near the string "ForceRechamberMilestone: Cannot force a rechamber on weapon '%s' that is not semi-auto."
+	let mut save = [0; 4];
+	if bin.scanner().finds_code(pat!("80B9 u4 00 [1-15] 488D0D${\"ForceRechamberMilestone: Cannot force a rechamber on weapon\"}"), &mut save) {
+		let singlefire = save[1];
+		let _ = writeln!(f.ini, "CWeaponX!m_singlefire={:#x}", singlefire);
+	}
+	else {
+		crate::print_error("unable to find weapon_singlefire");
 	}
 }
 

--- a/offsets/src/analysis/misc.rs
+++ b/offsets/src/analysis/misc.rs
@@ -17,7 +17,7 @@ pub fn print(f: &mut super::Output, bin: PeFile<'_>) {
 	view_render(f, bin);
 	client_state(f, bin);
 	projectile_speed(f, bin);
-	weapon_singlefire(f, bin);
+	weapon_is_semi_auto(f, bin);
 	unknown_magic(f, bin);
 	local_camera(f, bin);
 	studio_hdr(f, bin);
@@ -190,16 +190,16 @@ fn projectile_speed(f: &mut super::Output, bin: PeFile<'_>) {
 	}
 }
 
-fn weapon_singlefire(f: &mut super::Output, bin: PeFile<'_>) {
+fn weapon_is_semi_auto(f: &mut super::Output, bin: PeFile<'_>) {
 	// Credits: https://www.unknowncheats.me/forum/3403807-post9036.html
 	// Find near the string "ForceRechamberMilestone: Cannot force a rechamber on weapon '%s' that is not semi-auto."
 	let mut save = [0; 4];
 	if bin.scanner().finds_code(pat!("80B9 u4 00 [1-15] 488D0D${\"ForceRechamberMilestone: Cannot force a rechamber on weapon\"}"), &mut save) {
 		let singlefire = save[1];
-		let _ = writeln!(f.ini, "CWeaponX!m_singlefire={:#x}", singlefire);
+		let _ = writeln!(f.ini, "CWeaponX!m_isSemiAuto={:#x}", singlefire);
 	}
 	else {
-		crate::print_error("unable to find weapon_singlefire");
+		crate::print_error("unable to find weapon_is_semi_auto");
 	}
 }
 


### PR DESCRIPTION
This change introduces a new offset to the dump: CWeaponX!m_singlefire of type boolean that returns true when a players weapon is singlefire.
Learn more here: https://www.unknowncheats.me/forum/3403807-post9036.html

The pattern is based on the following function from the s14 dump in IDA (with opcode bytes to the left).
And has been tested on game dumps from June, July (2022-07-14) and August (s14) without the pattern breaking and outputting valid offsets.
![m_singlefire](https://user-images.githubusercontent.com/48806927/186155235-8e7d4de0-7a90-4245-a1fe-4aefcb6a935e.PNG)

