### PR TITLE
Add CWeaponX!m_zoomTimeIn pattern to misc.rs

### DIFF
--- a/offsets/src/analysis/misc.rs
+++ b/offsets/src/analysis/misc.rs
@@ -18,6 +18,7 @@ pub fn print(f: &mut super::Output, bin: PeFile<'_>) {
 	client_state(f, bin);
 	projectile_speed(f, bin);
 	weapon_is_semi_auto(f, bin);
+	weapon_zoom_time_in(f, bin);
 	unknown_magic(f, bin);
 	local_camera(f, bin);
 	studio_hdr(f, bin);
@@ -200,6 +201,17 @@ fn weapon_is_semi_auto(f: &mut super::Output, bin: PeFile<'_>) {
 	}
 	else {
 		crate::print_error("unable to find weapon_is_semi_auto");
+	}
+}
+
+fn weapon_zoom_time_in(f: &mut super::Output, bin: PeFile<'_>) {
+	let mut save = [0; 4];
+	if bin.scanner().finds_code(pat!("4885C0 75 %{ F30F1088 u4 0F57C0 0F2EC8 7A? }"), &mut save) {
+		let zoom_time_in = save[1];
+		let _ = writeln!(f.ini, "CWeaponX!m_zoomTimeIn={:#x}", zoom_time_in);
+	}
+	else {
+		crate::print_error("unable to find weapon_zoom_time_in");
 	}
 }
 


### PR DESCRIPTION
This change introduces a new offset to the dump: CWeaponX!m_zoomTimeIn of type Time/float that contains the absolute time for a weapon to be zoomed in completely. This can be used to calculate when your weapon is fully zoomed in and was originally reversed from the GetFracZoom function.

Learn more here: https://www.unknowncheats.me/forum/3523383-post10623.html
Discussion thread: https://www.unknowncheats.me/forum/apex-legends/319804-apex-legends-reversal-structs-offsets-532.html#post3523383

The pattern is based on the following function from my r5reloaded dump in IDA (with opcode bytes to the left).
And has been tested on game dumps from June, July (2022-07-14) and August (s14) without the pattern breaking and outputting valid offsets.
![m_zoomtimein](https://user-images.githubusercontent.com/48806927/194652273-5780d01b-4d72-466a-8498-38d1548c8f38.PNG)
